### PR TITLE
Github Release in CI instead of scheduled artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,15 @@
-name: "FAP: Build"
+name: "FAP: Build and Release"
 on:
   push:
     branches:
       - main
-  schedule:
-    # do a build every day
-    - cron: "1 1 * * *"
+permissions:
+  contents: write
+
 jobs:
   ufbt-build-action:
     runs-on: ubuntu-latest
-    name: "ufbt: Build for release candidate branch"
+    name: "ufbt: Build and publish release"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -19,8 +19,28 @@ jobs:
         with:
           # Set to 'release' to build for latest published release version
           sdk-channel: rc
-      - name: Upload app artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ github.event.repository.name }}-${{ steps.build-app.outputs.suffix }}
-          path: ${{ steps.build-app.outputs.fap-artifacts }}
+      - name: Check for existing release
+        id: check-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract fap_version from application.fam
+          FAP_VERSION=$(grep -oP 'fap_version\s*=\s*"\K[^"]+' application.fam)
+          TAG="v${FAP_VERSION}-${{ steps.build-app.outputs.suffix }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if gh release view "$TAG" --repo="${{ github.repository }}" &>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG does not exist yet — will create."
+          fi
+      - name: Create Release
+        if: steps.check-release.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.check-release.outputs.tag }}" \
+            --repo="${{ github.repository }}" \
+            --title="${{ github.event.repository.name }} ${{ steps.check-release.outputs.tag }}" \
+            ${{ steps.build-app.outputs.fap-artifacts }}


### PR DESCRIPTION
Tested on my fork. Publishes a release whenever the version number changes in a push to main. Releases don't expire like artifacts do so it doesn't need to be run on a schedule.